### PR TITLE
Fix Dockerfile trying to copy bad file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ RUN go run cmd/mage/main.go backend:genFrontend backend:genMigrations backend:bu
 FROM alpine:latest
 WORKDIR /root/
 COPY --from=backend /usr/src/app/dist/taskcafe .
-COPY --from=backend /usr/src/app/conf/app.example.toml conf/app.toml
+COPY --from=backend /usr/src/app/conf/taskcafe.example.toml conf/taskcafe.toml
 CMD ["./taskcafe", "web"]


### PR DESCRIPTION
The Build is currently failing due to the change in config where it now looks for `taskcafe.toml` instead of `app.toml`.

I've now updated the Dockerfile to copy across the correct filenames.

To check it's working run `docker-compose -p taskcafe up -d` and check the image is built correctly,
