### PR TITLE
fix: remove debug statements when logging in with incorrect password

### DIFF
--- a/internal/route/auth.go
+++ b/internal/route/auth.go
@@ -171,9 +171,8 @@ func (h *TaskcafeHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 	err = bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(requestData.Password))
 	if err != nil {
 		log.WithFields(log.Fields{
-			"password":      requestData.Password,
-			"password_hash": user.PasswordHash,
-		}).Warn("password incorrect")
+            "username": requestData.Username,
+        }).Warn("password incorrect for user")
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}


### PR DESCRIPTION
### Aim of the fix
Update to the login script to stop logging incorrect passwords for users in the logs. Noticed it was storing passwords in plain text which can compromise security.

### How to Test
Go to the login screen and enter a correct username, but incorrect password. Notice in the logs the password is no longer stored in plain text